### PR TITLE
feat: 支持通过订阅URL远程更新AI Mix配置

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,33 +121,3 @@ Prompt templates use `{variableName}` syntax for substitution with business data
 ## UI Development Guidelines
 
 **Prefer built-in Naive UI component props over custom CSS.** Custom CSS in `<style scoped>` should only be used when no built-in component or prop can achieve the desired result.
-
-### Examples
-
-Use Naive UI component props for styling instead of writing CSS classes:
-
-```vue
-<!-- ✅ 推荐：用 NButton tag="a" 实现可点击链接，无需任何 CSS -->
-<NButton
-  tag="a"
-  href="https://example.com"
-  target="_blank"
-  rel="noopener noreferrer"
-  circle
-  size="tiny"
-  type="info"
-  title="查看帮助文档"
->?</NButton>
-
-<!-- ❌ 避免：为链接按钮写自定义 CSS -->
-<span class="help-icon" @click="openLink">?</span>
-<style scoped>
-.help-icon { cursor: pointer; color: blue; ... }
-</style>
-```
-
-Other useful patterns:
-- Use `NSpace` with `align` / `size` props for layout instead of flexbox CSS
-- Use `NText` with `strong` / `type` / `depth` props for typography
-- Use `NAlert` with `type` prop (`success` / `warning` / `error` / `info`) for status messages
-- Use `NButton` with `block`, `size`, `type`, `circle`, `tag` props to cover most button variants

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,3 +117,37 @@ Prompt templates use `{variableName}` syntax for substitution with business data
 - **Security**: API keys are encrypted at rest using the extension's unique ID as the encryption key
 - **Permissions**: The extension requires optional host permissions for `https://*/*` to work across different GitLab/Jira instances
 - **Type paths**: WXT provides path aliases `@/` and `~/` pointing to the project root
+
+## UI Development Guidelines
+
+**Prefer built-in Naive UI component props over custom CSS.** Custom CSS in `<style scoped>` should only be used when no built-in component or prop can achieve the desired result.
+
+### Examples
+
+Use Naive UI component props for styling instead of writing CSS classes:
+
+```vue
+<!-- ✅ 推荐：用 NButton tag="a" 实现可点击链接，无需任何 CSS -->
+<NButton
+  tag="a"
+  href="https://example.com"
+  target="_blank"
+  rel="noopener noreferrer"
+  circle
+  size="tiny"
+  type="info"
+  title="查看帮助文档"
+>?</NButton>
+
+<!-- ❌ 避免：为链接按钮写自定义 CSS -->
+<span class="help-icon" @click="openLink">?</span>
+<style scoped>
+.help-icon { cursor: pointer; color: blue; ... }
+</style>
+```
+
+Other useful patterns:
+- Use `NSpace` with `align` / `size` props for layout instead of flexbox CSS
+- Use `NText` with `strong` / `type` / `depth` props for typography
+- Use `NAlert` with `type` prop (`success` / `warning` / `error` / `info`) for status messages
+- Use `NButton` with `block`, `size`, `type`, `circle`, `tag` props to cover most button variants

--- a/components/OptionsPage.vue
+++ b/components/OptionsPage.vue
@@ -98,8 +98,6 @@ const handleSubmit = async () => {
     await saveSubscriptionUrl(subscriptionUrl.value.trim());
 
     configMessage.value = '保存成功';
-    url.value = '';
-    apiKey.value = '';
 
     // 如果填写了订阅 URL，立即拉取一次
     const subUrl = subscriptionUrl.value.trim();

--- a/components/OptionsPage.vue
+++ b/components/OptionsPage.vue
@@ -280,13 +280,16 @@ onUnmounted(() => {
         <!-- AI Mix 配置管理 -->
         <NSpace align="center" :size="6">
           <NText strong>AI Mix 配置管理</NText>
-          <a
+          <NButton
+            tag="a"
             :href="AI_MIX_HELP_URL"
             target="_blank"
             rel="noopener noreferrer"
+            circle
+            size="tiny"
+            type="info"
             title="查看帮助文档"
-            class="help-icon"
-          >?</a>
+          >?</NButton>
         </NSpace>
 
         <!-- 订阅模式提示 -->
@@ -348,25 +351,5 @@ onUnmounted(() => {
 .options-container :deep(.n-card) {
   width: 100%;
   max-width: 800px;
-}
-
-.help-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background-color: #2080f0;
-  color: #fff;
-  font-size: 12px;
-  font-weight: bold;
-  text-decoration: none;
-  line-height: 1;
-  flex-shrink: 0;
-}
-
-.help-icon:hover {
-  background-color: #4098fc;
 }
 </style>

--- a/components/OptionsPage.vue
+++ b/components/OptionsPage.vue
@@ -280,13 +280,13 @@ onUnmounted(() => {
         <!-- AI Mix 配置管理 -->
         <NSpace align="center" :size="6">
           <NText strong>AI Mix 配置管理</NText>
-          <NButton
-            circle
-            size="tiny"
-            type="info"
+          <a
+            :href="AI_MIX_HELP_URL"
+            target="_blank"
+            rel="noopener noreferrer"
             title="查看帮助文档"
-            @click="() => browser.tabs.create({ url: AI_MIX_HELP_URL })"
-          >?</NButton>
+            class="help-icon"
+          >?</a>
         </NSpace>
 
         <!-- 订阅模式提示 -->
@@ -348,5 +348,25 @@ onUnmounted(() => {
 .options-container :deep(.n-card) {
   width: 100%;
   max-width: 800px;
+}
+
+.help-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: #2080f0;
+  color: #fff;
+  font-size: 12px;
+  font-weight: bold;
+  text-decoration: none;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.help-icon:hover {
+  background-color: #4098fc;
 }
 </style>

--- a/components/OptionsPage.vue
+++ b/components/OptionsPage.vue
@@ -44,6 +44,14 @@ const importMode = ref<'merge' | 'replace'>('merge');
 // 当填写了订阅 URL 时，JSON 编辑器只读
 const isAiMixReadonly = computed(() => !!subscriptionUrl.value.trim());
 
+// 订阅 URL 使用 http 时提示安全风险（用户仍可强制保存）
+const isSubscriptionInsecure = computed(() =>
+  subscriptionUrl.value.trim().toLowerCase().startsWith('http://')
+);
+
+/** AI Mix 帮助文档链接 */
+const AI_MIX_HELP_URL = 'https://github.com/wecode-ai/wegent-browser-power/wiki/%E9%AB%98%E7%BA%A7%E4%BD%BF%E7%94%A8';
+
 // 加载配置
 const loadConfig = async () => {
   // 加载原有配置
@@ -242,6 +250,14 @@ onUnmounted(() => {
               />
             </NFormItem>
 
+            <!-- http 不安全提示：用户可忽略，仍可保存 -->
+            <NAlert
+              v-if="isSubscriptionInsecure"
+              type="warning"
+              title="订阅地址使用 http，配置内容将通过未加密连接传输，存在安全风险"
+              description="建议将地址改为 https://，也可忽略此提示并直接保存。"
+            />
+
             <NButton
               type="primary"
               size="large"
@@ -262,7 +278,16 @@ onUnmounted(() => {
         <NDivider />
 
         <!-- AI Mix 配置管理 -->
-        <NText strong>AI Mix 配置管理</NText>
+        <NSpace align="center" :size="6">
+          <NText strong>AI Mix 配置管理</NText>
+          <NButton
+            circle
+            size="tiny"
+            type="info"
+            title="查看帮助文档"
+            @click="() => window.open(AI_MIX_HELP_URL, '_blank')"
+          >?</NButton>
+        </NSpace>
 
         <!-- 订阅模式提示 -->
         <NAlert

--- a/components/OptionsPage.vue
+++ b/components/OptionsPage.vue
@@ -68,7 +68,12 @@ const fetchSubscription = async (subUrl: string): Promise<boolean> => {
   try {
     const response = await fetch(subUrl, {
       method: 'GET',
-      headers: { 'Accept': 'application/json' },
+      cache: 'no-cache',
+      headers: {
+        'Accept': 'application/json',
+        'Cache-Control': 'no-cache',
+        'Pragma': 'no-cache',
+      },
     });
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/components/OptionsPage.vue
+++ b/components/OptionsPage.vue
@@ -20,6 +20,7 @@ import {
   importAIMixConfig,
   resetAIMixConfig,
   loadDefaultAIMixConfig,
+  applySubscriptionData,
   type AIMixConfig,
 } from '@/services/config';
 
@@ -57,18 +58,27 @@ const loadConfig = async () => {
   aiMixJson.value = JSON.stringify(aiMixConfig, null, 2);
 };
 
-// 拉取订阅配置（通过 background script 绕过 CORS）
+// 拉取订阅配置
+// 直接在 Options 页面（扩展页）发起 fetch：
+// permissions.request() 在此页面授权后立即生效，无需等待 Service Worker 同步权限
+// 避免了 Chrome MV3 中权限刚授予但 Service Worker 尚未感知的竞态问题
 const fetchSubscription = async (subUrl: string): Promise<boolean> => {
   subscriptionStatus.value = 'loading';
   subscriptionError.value = '';
   try {
-    const resp = await browser.runtime.sendMessage({
-      action: 'fetchSubscription',
-      url: subUrl,
-    }) as { success: boolean; error?: string };
-    if (!resp.success) {
-      throw new Error(resp.error || '未知错误');
+    const response = await fetch(subUrl, {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
+    const data = (await response.json()) as AIMixConfig;
+    // 简单校验：至少包含一个已知平台字段
+    if (!data || (!data.dingTalk && !data.gitLab && !data.jira)) {
+      throw new Error('订阅数据格式错误：缺少 dingTalk / gitLab / jira 字段');
+    }
+    await applySubscriptionData(data);
     subscriptionStatus.value = 'success';
     // 重新加载 AI Mix 配置展示
     const aiMixConfig = await getAIMixConfig();

--- a/components/OptionsPage.vue
+++ b/components/OptionsPage.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, onUnmounted } from 'vue';
 import {
   NCard,
   NForm,
@@ -21,6 +21,7 @@ import {
   resetAIMixConfig,
   loadDefaultAIMixConfig,
   applySubscriptionData,
+  AI_MIX_CONFIG_KEY,
   type AIMixConfig,
 } from '@/services/config';
 
@@ -183,6 +184,28 @@ const handleReset = async () => {
 };
 
 onMounted(loadConfig);
+
+// 监听 background onStartup 拉取后 storage 的变化
+// 解决竞态：用户打开页面时 onStartup fetch 可能尚未完成，
+// fetch 完成写入 storage 后，此监听器自动刷新 AI Mix 配置展示
+const onStorageChanged = (
+  changes: Record<string, browser.storage.StorageChange>,
+  area: string
+) => {
+  if (area === 'local' && AI_MIX_CONFIG_KEY in changes) {
+    getAIMixConfig().then(config => {
+      aiMixJson.value = JSON.stringify(config, null, 2);
+    });
+  }
+};
+
+onMounted(() => {
+  browser.storage.onChanged.addListener(onStorageChanged);
+});
+
+onUnmounted(() => {
+  browser.storage.onChanged.removeListener(onStorageChanged);
+});
 </script>
 
 <template>

--- a/components/OptionsPage.vue
+++ b/components/OptionsPage.vue
@@ -88,6 +88,33 @@ const handleSubmit = async () => {
     return;
   }
 
+  // 同步提取订阅 URL（必须在任何 await 之前完成，保持用户手势上下文）
+  const subUrl = subscriptionUrl.value.trim();
+
+  // 若填写了订阅 URL，立即申请对应域名的访问权限
+  // permissions.request() 必须是第一个 await，Chrome 才能识别用户手势并弹出授权弹框
+  if (subUrl) {
+    let origin: string;
+    try {
+      const urlObj = new URL(subUrl);
+      if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
+        configMessage.value = '订阅URL仅支持 http 或 https 协议';
+        return;
+      }
+      origin = `${urlObj.protocol}//${urlObj.host}/*`;
+    } catch {
+      configMessage.value = '订阅URL格式无效，请检查后重试';
+      return;
+    }
+
+    // ⚠️ 此处是整个函数的第一个 await，Chrome 的用户手势上下文仍然有效
+    const granted = await browser.permissions.request({ origins: [origin] });
+    if (!granted) {
+      // 用户点了"拒绝"，提示但仍继续保存基础配置
+      message.warning('已拒绝访问权限，订阅配置将无法拉取，基础配置仍会保存');
+    }
+  }
+
   try {
     await saveConfig({
       wegent_url: url.value,
@@ -95,12 +122,11 @@ const handleSubmit = async () => {
     });
 
     // 同步保存订阅 URL
-    await saveSubscriptionUrl(subscriptionUrl.value.trim());
+    await saveSubscriptionUrl(subUrl);
 
     configMessage.value = '保存成功';
 
-    // 如果填写了订阅 URL，立即拉取一次
-    const subUrl = subscriptionUrl.value.trim();
+    // 权限已申请，立即拉取一次订阅配置
     if (subUrl) {
       const ok = await fetchSubscription(subUrl);
       if (ok) {

--- a/components/OptionsPage.vue
+++ b/components/OptionsPage.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import {
   NCard,
   NForm,
@@ -14,7 +14,7 @@ import {
   NRadio,
   useMessage,
 } from 'naive-ui';
-import { getConfig, saveConfig } from '@/services/config';
+import { getConfig, saveConfig, saveSubscriptionUrl, getSubscriptionUrl } from '@/services/config';
 import {
   getAIMixConfig,
   importAIMixConfig,
@@ -30,9 +30,17 @@ const url = ref('');
 const apiKey = ref('');
 const configMessage = ref('');
 
+// 订阅 URL
+const subscriptionUrl = ref('');
+const subscriptionStatus = ref<'idle' | 'loading' | 'success' | 'error'>('idle');
+const subscriptionError = ref('');
+
 // AI Mix 配置
 const aiMixJson = ref('');
 const importMode = ref<'merge' | 'replace'>('merge');
+
+// 当填写了订阅 URL 时，JSON 编辑器只读
+const isAiMixReadonly = computed(() => !!subscriptionUrl.value.trim());
 
 // 加载配置
 const loadConfig = async () => {
@@ -41,9 +49,36 @@ const loadConfig = async () => {
   url.value = config.wegent_url || '';
   apiKey.value = config.wegent_api_key || '';
 
+  // 加载订阅 URL
+  subscriptionUrl.value = await getSubscriptionUrl();
+
   // 加载 AI Mix 配置（优先本地存储，无则加载默认配置）
   const aiMixConfig = await getAIMixConfig();
   aiMixJson.value = JSON.stringify(aiMixConfig, null, 2);
+};
+
+// 拉取订阅配置（通过 background script 绕过 CORS）
+const fetchSubscription = async (subUrl: string): Promise<boolean> => {
+  subscriptionStatus.value = 'loading';
+  subscriptionError.value = '';
+  try {
+    const resp = await browser.runtime.sendMessage({
+      action: 'fetchSubscription',
+      url: subUrl,
+    }) as { success: boolean; error?: string };
+    if (!resp.success) {
+      throw new Error(resp.error || '未知错误');
+    }
+    subscriptionStatus.value = 'success';
+    // 重新加载 AI Mix 配置展示
+    const aiMixConfig = await getAIMixConfig();
+    aiMixJson.value = JSON.stringify(aiMixConfig, null, 2);
+    return true;
+  } catch (error) {
+    subscriptionStatus.value = 'error';
+    subscriptionError.value = (error as Error).message;
+    return false;
+  }
 };
 
 // 保存原有配置
@@ -58,10 +93,24 @@ const handleSubmit = async () => {
       wegent_url: url.value,
       wegent_api_key: apiKey.value
     });
-    configMessage.value = '保存成功';
 
+    // 同步保存订阅 URL
+    await saveSubscriptionUrl(subscriptionUrl.value.trim());
+
+    configMessage.value = '保存成功';
     url.value = '';
     apiKey.value = '';
+
+    // 如果填写了订阅 URL，立即拉取一次
+    const subUrl = subscriptionUrl.value.trim();
+    if (subUrl) {
+      const ok = await fetchSubscription(subUrl);
+      if (ok) {
+        message.success('订阅配置已更新');
+      } else {
+        message.error('订阅配置拉取失败: ' + subscriptionError.value);
+      }
+    }
   } catch (error) {
     configMessage.value = '保存失败' + error;
   }
@@ -122,6 +171,15 @@ onMounted(loadConfig);
               />
             </NFormItem>
 
+            <NFormItem label="订阅URL">
+              <NInput
+                v-model:value="subscriptionUrl"
+                placeholder="可选，填写后 AI Mix 配置将由此 URL 远程管理（支持 http / https）"
+                size="large"
+                clearable
+              />
+            </NFormItem>
+
             <NButton
               type="primary"
               size="large"
@@ -144,8 +202,22 @@ onMounted(loadConfig);
         <!-- AI Mix 配置管理 -->
         <NText strong>AI Mix 配置管理</NText>
 
+        <!-- 订阅模式提示 -->
+        <NAlert
+          v-if="isAiMixReadonly"
+          type="info"
+          title="当前配置由订阅 URL 管理，不可手动编辑"
+          :description="`订阅地址：${subscriptionUrl}`"
+        />
+        <NAlert
+          v-if="subscriptionStatus === 'error'"
+          type="error"
+          :title="`订阅配置拉取失败：${subscriptionError}`"
+        />
+
         <NSpace vertical :size="16">
-          <NRadioGroup v-model:value="importMode">
+          <!-- 非订阅模式才显示合并/替换选项 -->
+          <NRadioGroup v-if="!isAiMixReadonly" v-model:value="importMode">
             <NSpace>
               <NRadio value="merge">合并（不影响其他配置）</NRadio>
               <NRadio value="replace">替换（完全覆盖）</NRadio>
@@ -160,10 +232,12 @@ onMounted(loadConfig);
               :rows="20"
               placeholder="AI Mix 配置 JSON"
               style="font-family: monospace;"
+              :disabled="isAiMixReadonly"
             />
           </NFormItem>
 
-          <NSpace>
+          <!-- 非订阅模式才显示操作按钮 -->
+          <NSpace v-if="!isAiMixReadonly">
             <NButton type="primary" @click="handleImport">保存</NButton>
             <NButton type="error" @click="handleReset">重置为默认</NButton>
           </NSpace>

--- a/components/OptionsPage.vue
+++ b/components/OptionsPage.vue
@@ -254,7 +254,7 @@ onUnmounted(() => {
             <NAlert
               v-if="isSubscriptionInsecure"
               type="warning"
-              title="订阅地址使用 http，配置内容将通过未加密连接传输，存在安全风险"
+              title="订阅地址使用http，配置内容将通过未加密连接传输，存在安全风险！建议用https"
               description="建议将地址改为 https://，也可忽略此提示并直接保存。"
             />
 

--- a/components/OptionsPage.vue
+++ b/components/OptionsPage.vue
@@ -285,7 +285,7 @@ onUnmounted(() => {
             size="tiny"
             type="info"
             title="查看帮助文档"
-            @click="() => window.open(AI_MIX_HELP_URL, '_blank')"
+            @click="() => browser.tabs.create({ url: AI_MIX_HELP_URL })"
           >?</NButton>
         </NSpace>
 

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -78,9 +78,25 @@ export default defineBackground(() => {
   }
 
   // 在后台静默拉取订阅配置（不要求成功）
+  // onStartup 无用户手势，无法调用 permissions.request()
+  // 需先用 permissions.contains() 确认用户已在 Options 页授权，否则跳过
   async function fetchSubscriptionConfig() {
     const url = await getSubscriptionUrl();
     if (!url) return;
+
+    try {
+      const urlObj = new URL(url);
+      const origin = `${urlObj.protocol}//${urlObj.host}/*`;
+      const hasPermission = await browser.permissions.contains({ origins: [origin] });
+      if (!hasPermission) {
+        console.log('订阅URL尚未获得访问授权，跳过自动拉取:', origin);
+        return;
+      }
+    } catch (error) {
+      console.error('检查订阅URL权限失败:', error);
+      return;
+    }
+
     await handleFetchSubscription(url);
   }
 

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { saveConfig } from '@/services/config';
+import { saveConfig, getSubscriptionUrl, applySubscriptionData, type AIMixConfig } from '@/services/config';
 
 export default defineBackground(() => {
   console.log('Hello background!', { id: browser.runtime.id });
@@ -11,6 +11,10 @@ export default defineBackground(() => {
   // 监听扩展启动事件
   browser.runtime.onStartup.addListener(() => {
     console.log('Extension started');
+    // 浏览器启动时自动拉取订阅配置
+    fetchSubscriptionConfig().catch(err =>
+      console.error('启动时拉取订阅配置失败:', err)
+    );
   });
 
   // 监听来自 popup 的消息
@@ -28,6 +32,12 @@ export default defineBackground(() => {
       return true; // 保持消息通道开放以支持异步响应
     }
 
+    // 拉取订阅 URL 并更新 AI Mix 配置
+    if (message.action === 'fetchSubscription') {
+      handleFetchSubscription(message.url).then(sendResponse);
+      return true;
+    }
+
     // 启动钉钉Markdown下载监听事件
     if (message.action === 'waitForDingMarkdownDownload') {
       handleDingMarkdownDownload(message.origin).then(sendResponse);
@@ -40,6 +50,39 @@ export default defineBackground(() => {
       return true; // 保持消息通道开放以支持异步响应
     }
   });
+
+  // 从订阅 URL 拉取并应用 AI Mix 配置
+  // Background Service Worker 拥有扩展 Host Permission，fetch 不受目标服务器 CORS 限制
+  async function handleFetchSubscription(url: string) {
+    try {
+      console.log('开始拉取订阅配置:', url);
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: { 'Accept': 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      const data = (await response.json()) as AIMixConfig;
+      // 简单校验：至少包含一个已知平台字段
+      if (!data || (!data.dingTalk && !data.gitLab && !data.jira)) {
+        throw new Error('订阅数据格式错误：缺少 dingTalk / gitLab / jira 字段');
+      }
+      await applySubscriptionData(data);
+      console.log('订阅配置已更新');
+      return { success: true };
+    } catch (error) {
+      console.error('拉取订阅配置失败:', error);
+      return { success: false, error: (error as Error).message };
+    }
+  }
+
+  // 在后台静默拉取订阅配置（不要求成功）
+  async function fetchSubscriptionConfig() {
+    const url = await getSubscriptionUrl();
+    if (!url) return;
+    await handleFetchSubscription(url);
+  }
 
   // 自动配置函数
   async function handleAutoConfig(currentUrl: string) {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -58,7 +58,12 @@ export default defineBackground(() => {
       console.log('开始拉取订阅配置:', url);
       const response = await fetch(url, {
         method: 'GET',
-        headers: { 'Accept': 'application/json' },
+        cache: 'no-cache',
+        headers: {
+          'Accept': 'application/json',
+          'Cache-Control': 'no-cache',
+          'Pragma': 'no-cache',
+        },
       });
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -82,7 +82,10 @@ export default defineBackground(() => {
   // 需先用 permissions.contains() 确认用户已在 Options 页授权，否则跳过
   async function fetchSubscriptionConfig() {
     const url = await getSubscriptionUrl();
-    if (!url) return;
+    if (!url) {
+      console.log('未配置订阅 URL，跳过更新');
+      return;
+    }
 
     try {
       const urlObj = new URL(url);

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,20 +1,54 @@
 import { saveConfig, getSubscriptionUrl, applySubscriptionData, type AIMixConfig } from '@/services/config';
 
+/** 订阅配置定时轮询的 Alarm 名称 */
+const SUBSCRIPTION_ALARM_NAME = 'subscription-config-sync';
+
+/** 轮询间隔（分钟），6 小时 */
+const SUBSCRIPTION_ALARM_INTERVAL_MINUTES = 6 * 60;
+
 export default defineBackground(() => {
   console.log('Hello background!', { id: browser.runtime.id });
-  
+
+  // 注册/恢复定时轮询 Alarm
+  // Alarm 在 Service Worker 休眠期间由系统维护，唤醒后自动触发
+  const ensureAlarm = async () => {
+    const existing = await browser.alarms.get(SUBSCRIPTION_ALARM_NAME);
+    if (!existing) {
+      browser.alarms.create(SUBSCRIPTION_ALARM_NAME, {
+        periodInMinutes: SUBSCRIPTION_ALARM_INTERVAL_MINUTES,
+      });
+      console.log(`订阅轮询 Alarm 已注册，间隔 ${SUBSCRIPTION_ALARM_INTERVAL_MINUTES} 分钟`);
+    }
+  };
+
   // 监听扩展安装或更新事件
   browser.runtime.onInstalled.addListener(() => {
     console.log('Extension installed or updated');
+    ensureAlarm();
+    // 安装/更新时立即拉取一次，确保第一次使用即最新配置
+    fetchSubscriptionConfig().catch(err =>
+      console.error('安装/更新时拉取订阅配置失败:', err)
+    );
   });
 
   // 监听扩展启动事件
   browser.runtime.onStartup.addListener(() => {
     console.log('Extension started');
+    ensureAlarm();
     // 浏览器启动时自动拉取订阅配置
     fetchSubscriptionConfig().catch(err =>
       console.error('启动时拉取订阅配置失败:', err)
     );
+  });
+
+  // 监听定时 Alarm，触发订阅配置轮询
+  browser.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === SUBSCRIPTION_ALARM_NAME) {
+      console.log('定时轮询触发，开始拉取订阅配置');
+      fetchSubscriptionConfig().catch(err =>
+        console.error('定时轮询拉取订阅配置失败:', err)
+      );
+    }
   });
 
   // 监听来自 popup 的消息

--- a/services/config.ts
+++ b/services/config.ts
@@ -17,6 +17,8 @@ export interface ExtensionConfig {
   wegent_api_key?: string;
   /** API 密钥是否已加密（用于兼容旧版数据） */
   wegent_api_key_encrypted?: boolean;
+  /** AI Mix 配置订阅 URL，填写后 AI Mix 配置由远程管理，本地不可手动编辑 */
+  subscription_url?: string;
 }
 
 /**
@@ -316,4 +318,41 @@ export async function resetAIMixConfig(): Promise<void> {
     console.error('重置 AI Mix 配置失败:', error);
     throw error;
   }
+}
+
+/**
+ * 获取订阅 URL
+ */
+export async function getSubscriptionUrl(): Promise<string> {
+  const config = await getConfig();
+  return config.subscription_url || '';
+}
+
+/**
+ * 保存订阅 URL
+ */
+export async function saveSubscriptionUrl(url: string): Promise<void> {
+  try {
+    const rawData = await browser.storage.local.get(STORAGE_KEY) as {
+      [STORAGE_KEY]?: ExtensionConfig;
+    };
+    const rawConfig = rawData[STORAGE_KEY] || {};
+    await browser.storage.local.set({
+      [STORAGE_KEY]: { ...rawConfig, subscription_url: url },
+    });
+  } catch (error) {
+    console.error('保存订阅 URL 失败:', error);
+    throw error;
+  }
+}
+
+/**
+ * 将从订阅 URL 获取到的数据写入 AI Mix 配置（完整替换）
+ */
+export async function applySubscriptionData(data: AIMixConfig): Promise<void> {
+  const config: AIMixStorageConfig = {};
+  if (data.dingTalk?.actions) config.dingTalk = { actions: data.dingTalk.actions };
+  if (data.gitLab?.actions) config.gitLab = { actions: data.gitLab.actions };
+  if (data.jira?.actions) config.jira = { actions: data.jira.actions };
+  await saveAIMixConfig(config);
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'wxt';
 export default defineConfig({
   modules: ['@wxt-dev/module-vue'],
   manifest: {
-    permissions: ['storage', 'tabs', 'scripting', 'notifications', 'downloads'],
+    permissions: ['storage', 'tabs', 'scripting', 'notifications', 'downloads', 'alarms'],
     host_permissions: ['https://alidocs.dingtalk.com/*'],
     optional_host_permissions: ['https://*/*', 'http://*/*'],
   },

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
   modules: ['@wxt-dev/module-vue'],
   manifest: {
     permissions: ['storage', 'tabs', 'scripting', 'notifications', 'downloads'],
-    host_permissions: ['https://alidocs.dingtalk.com/*'],
-    optional_host_permissions: ['https://*/*', 'http://*/*'],
+    host_permissions: ['https://alidocs.dingtalk.com/*', 'https://*/*', 'http://*/*'],
+    optional_host_permissions: [],
   },
   webExt: {
     disabled: true, // 禁用 WXT 自动启动浏览器

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
   modules: ['@wxt-dev/module-vue'],
   manifest: {
     permissions: ['storage', 'tabs', 'scripting', 'notifications', 'downloads'],
-    host_permissions: ['https://alidocs.dingtalk.com/*', 'https://*/*', 'http://*/*'],
-    optional_host_permissions: [],
+    host_permissions: ['https://alidocs.dingtalk.com/*'],
+    optional_host_permissions: ['https://*/*', 'http://*/*'],
   },
   webExt: {
     disabled: true, // 禁用 WXT 自动启动浏览器


### PR DESCRIPTION
## 功能概述

新增**订阅URL**功能，允许通过远程 JSON 文件统一管理 AI Mix 配置，适合团队统一下发配置场景。

## 新增功能

### 订阅URL管理
- 插件选项页新增「订阅URL」输入框（可选，支持 http / https）
- 填写后 AI Mix 配置 JSON 区域切换为**只读**，配置由远程管理
- 订阅URL使用 `http://` 时展示安全警告，用户可忽略并强制保存

### 自动同步策略（4个触发时机）
| 时机 | 说明 |
|------|------|
| 点击「保存基础配置」 | 立即拉取一次 |
| 浏览器启动 `onStartup` | 每次启动自动同步 |
| 扩展安装/更新 `onInstalled` | 首次即最新 |
| **定时轮询 `chrome.alarms`** | 每 6 小时自动后台同步 |

### CORS 解决方案
- 保存时通过 `permissions.request()` 动态申请目标域名权限（弹框授权，最小权限原则）
- Options 页面直接 fetch（扩展页面持有权限后无 CORS 限制，避免 Service Worker 权限同步竞态）
- background `onStartup` 通过 `permissions.contains()` 检查权限后拉取

### 其他优化
- fetch 请求加入 `cache: 'no-cache'` 防止 disk cache 导致配置不更新
- Options 页监听 `browser.storage.onChanged`，background 更新配置后页面自动刷新（解决一次重启不生效的竞态问题）
- AI Mix 配置管理标题旁新增帮助文档链接图标

## 涉及文件
- `services/config.ts` — 新增 `subscription_url` 字段及相关工具函数
- `entrypoints/background.ts` — 订阅拉取逻辑、alarms 定时轮询
- `components/OptionsPage.vue` — 订阅URL输入、只读模式、安全警告、帮助图标
- `wxt.config.ts` — 新增 `alarms` 权限