### PR TITLE
fix: wegent_code_bot 工具配置时提交后跳转至 /code 而非 /chat

### DIFF
--- a/components/include/AIAction.vue
+++ b/components/include/AIAction.vue
@@ -140,7 +140,9 @@ const handleConfirmSubmit = async () => {
 
     const wegentBaseUrl = (wegentApi as any)['baseUrl'];
     const taskId = apiResponse.id.replace('resp_', '');
-    const chatUrl = `${wegentBaseUrl}/chat?taskId=${taskId}`;
+    const hasCodeBot = resolvedAiConfig.value.tools?.some((t) => t.type === 'wegent_code_bot');
+    const targetPath = hasCodeBot ? 'code' : 'chat';
+    const chatUrl = `${wegentBaseUrl}/${targetPath}?taskId=${taskId}`;
 
     message.success('AI 任务已创建！');
     console.log('任务已创建，ID:', apiResponse.id);


### PR DESCRIPTION
## 问题描述

当 AI Mix 配置的 tools 中包含 `"type": "wegent_code_bot"` 时，提交后应跳转至 `/code`，但实际跳转到了 `/chat`。

关联 Issue：wecode-ai/wegent-browser-power#5

## 根因分析

`components/include/AIAction.vue` 的 `handleConfirmSubmit` 函数中，跳转 URL 被硬编码为 `/chat`，未根据 tools 配置动态判断。

## 修改内容

**文件**：`components/include/AIAction.vue`

在提交成功后，检查 `resolvedAiConfig.tools` 中是否存在 `wegent_code_bot` 类型的工具：
- 存在 `wegent_code_bot` → 跳转至 `/code?taskId=...`
- 否则 → 跳转至 `/chat?taskId=...`（原有行为不变）

## 变更范围

- 仅修改 `AIAction.vue` 第 141-145 行跳转逻辑，改动量极小
- 未配置 `wegent_code_bot` 的场景行为完全不变