### PR TITLE
feat(dingtalk): add download permission check for DingTalk documents

### DIFF
--- a/components/DingTalkPage.vue
+++ b/components/DingTalkPage.vue
@@ -1,10 +1,11 @@
 <script lang="ts" setup>
 import { ref, onMounted } from 'vue';
-import { NCard, NSpace, NText } from 'naive-ui';
+import { NCard, NSpace, NText, useMessage } from 'naive-ui';
 import AIMix from './include/AIMix.vue';
 import { getAIMixConfig } from '../services/config';
 import type { AIMixActionItem } from '../services/config';
 
+const message = useMessage();
 const isDingTalkDoc = ref(false);
 
 // AI 操作配置数组（动态加载）
@@ -34,6 +35,15 @@ const checkDingTalkDoc = async () => {
 };
 
 /**
+ * 显示错误提示
+ */
+const showError = (error: unknown) => {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  message.error(errorMessage);
+  console.error('钉钉文档操作失败:', error);
+};
+
+/**
  * 获取钉钉文档 Markdown 内容
  * 封装：触发导出 → 监听下载 → 读取文件内容
  * 返回对象，key 对应 prompt 模板中的变量名 {content}
@@ -44,7 +54,9 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
       const [activeTab] = await browser.tabs.query({ active: true, currentWindow: true });
 
       if (!activeTab || !activeTab.id) {
-        reject(new Error('无法获取当前标签页'));
+        const error = new Error('无法获取当前标签页');
+        showError(error);
+        reject(error);
         return;
       }
 
@@ -56,7 +68,9 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
       browser.runtime.sendMessage({ action: 'waitForDingMarkdownDownload', origin: pageOrigin }, async (response) => {
         console.log('下载对象:', response);
         if (!response?.success || !response?.downloadItem?.finalUrl) {
-          reject(new Error('未获取到下载文件'));
+          const error = new Error('未获取到下载文件');
+          showError(error);
+          reject(error);
           return;
         }
 
@@ -64,7 +78,9 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
           const res = await fetch(response.downloadItem.finalUrl);
 
           if (!res.ok) {
-            reject(new Error(`下载失败: ${res.status}`));
+            const error = new Error(`下载失败: ${res.status}`);
+            showError(error);
+            reject(error);
             return;
           }
 
@@ -73,6 +89,7 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
           console.log('Markdown 内容:', text);
           resolve({ content: text });
         } catch (error) {
+          showError(error);
           reject(error);
         }
       });
@@ -147,11 +164,14 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
         },
       });
 
-      // 检查脚本执行结果
+      // 检查脚本执行结果 - 如果页面内 Promise reject，结果会包含异常信息
       if (scriptResult?.error) {
-        throw new Error(scriptResult.error.message || '页面脚本执行失败');
+        const error = new Error(scriptResult.error.message || '页面脚本执行失败');
+        showError(error);
+        throw error;
       }
     } catch (error) {
+      showError(error);
       reject(error);
     }
   });

--- a/components/DingTalkPage.vue
+++ b/components/DingTalkPage.vue
@@ -78,7 +78,7 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
       });
 
       // 在页面中执行导出操作
-      await browser.scripting.executeScript({
+      const [scriptResult] = await browser.scripting.executeScript({
         target: { tabId: activeTab.id },
         func: () => {
           return new Promise<void>((resolve, reject) => {
@@ -146,6 +146,11 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
           });
         },
       });
+
+      // 检查脚本执行结果
+      if (scriptResult?.error) {
+        throw new Error(scriptResult.error.message || '页面脚本执行失败');
+      }
     } catch (error) {
       reject(error);
     }

--- a/components/DingTalkPage.vue
+++ b/components/DingTalkPage.vue
@@ -87,6 +87,50 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
               const iframe = document.getElementById('wiki-doc-iframe') as HTMLIFrameElement;
               const targetDocument = (iframe && iframe.contentDocument) ? iframe.contentDocument : document;
 
+              // 处理导出按钮的函数
+              const handleExportButton = (exportButton: HTMLElement) => {
+                // 检测类名中是否包含以 -disabled 结尾的类名
+                const classList = Array.from(exportButton.classList);
+                const hasDisabledClass = classList.some(cls => cls.endsWith('-disabled'));
+
+                if (hasDisabledClass) {
+                  resolve({ success: false, error: '您没有当前文档的下载权限，请联系文档所有者申请"可查看/可下载"权限' });
+                  return;
+                }
+
+                // 有权限，继续导出流程
+                const rect = exportButton.getBoundingClientRect();
+                const events = ['pointerover', 'pointerenter', 'mouseover', 'mouseenter'];
+                events.forEach(type => {
+                  exportButton.dispatchEvent(new PointerEvent(type, {
+                    bubbles: true,
+                    cancelable: true,
+                    composed: true,
+                    clientX: rect.left + rect.width / 2,
+                    clientY: rect.top + rect.height / 2,
+                    view: window,
+                  }));
+                });
+
+                setTimeout(() => {
+                  const exportMdButton = targetDocument.querySelector('[data-role="operationBar__export_exportAsMd"]');
+                  if (exportMdButton) {
+                    (exportMdButton as HTMLElement).click();
+                    resolve({ success: true });
+                  } else {
+                    resolve({ success: false, error: '未找到导出为 Markdown 按钮' });
+                  }
+                }, 500);
+              };
+
+              // 先检查导出按钮是否已可见（菜单已打开）
+              const existingExportButton = targetDocument.querySelector('[data-role="operationBar_export"]') as HTMLElement;
+              if (existingExportButton) {
+                // 菜单已打开，直接处理
+                handleExportButton(existingExportButton);
+                return;
+              }
+
               const headerButton = targetDocument.querySelector('button[data-role="headerMoreMenu"]');
               if (!headerButton) {
                 resolve({ success: false, error: '未找到 headerMoreMenu 按钮' });
@@ -102,41 +146,10 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
 
               const checkExportButton = () => {
                 attempts++;
-                const exportButton = targetDocument.querySelector('[data-role="operationBar_export"]');
+                const exportButton = targetDocument.querySelector('[data-role="operationBar_export"]') as HTMLElement;
 
                 if (exportButton) {
-                  // 检测类名中是否包含以 -disabled 结尾的类名
-                  const classList = Array.from(exportButton.classList);
-                  const hasDisabledClass = classList.some(cls => cls.endsWith('-disabled'));
-
-                  if (hasDisabledClass) {
-                    resolve({ success: false, error: '您没有当前文档的下载权限，请联系文档所有者申请"可查看/可下载"权限' });
-                    return;
-                  }
-
-                  // 有权限，继续导出流程
-                  const rect = (exportButton as HTMLElement).getBoundingClientRect();
-                  const events = ['pointerover', 'pointerenter', 'mouseover', 'mouseenter'];
-                  events.forEach(type => {
-                    (exportButton as HTMLElement).dispatchEvent(new PointerEvent(type, {
-                      bubbles: true,
-                      cancelable: true,
-                      composed: true,
-                      clientX: rect.left + rect.width / 2,
-                      clientY: rect.top + rect.height / 2,
-                      view: window,
-                    }));
-                  });
-
-                  setTimeout(() => {
-                    const exportMdButton = targetDocument.querySelector('[data-role="operationBar__export_exportAsMd"]');
-                    if (exportMdButton) {
-                      (exportMdButton as HTMLElement).click();
-                      resolve({ success: true });
-                    } else {
-                      resolve({ success: false, error: '未找到导出为 Markdown 按钮' });
-                    }
-                  }, 500);
+                  handleExportButton(exportButton);
                 } else if (attempts >= maxAttempts) {
                   resolve({ success: false, error: '查找导出按钮超时，最多尝试20次' });
                 } else {

--- a/components/DingTalkPage.vue
+++ b/components/DingTalkPage.vue
@@ -85,16 +85,14 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
             const iframe = document.getElementById('wiki-doc-iframe') as HTMLIFrameElement;
             const targetDocument = (iframe && iframe.contentDocument) ? iframe.contentDocument : document;
 
-            let exportButton = targetDocument.querySelector('[data-role="operationBar_export"]');
-
-            if (!exportButton) {
-              const headerButton = targetDocument.querySelector('button[data-role="headerMoreMenu"]');
-              if (!headerButton) {
-                reject(new Error('未找到 headerMoreMenu 按钮'));
-                return;
-              }
-              (headerButton as HTMLElement).click();
+            const headerButton = targetDocument.querySelector('button[data-role="headerMoreMenu"]');
+            if (!headerButton) {
+              reject(new Error('未找到 headerMoreMenu 按钮'));
+              return;
             }
+
+            // 点击菜单按钮展开选项
+            (headerButton as HTMLElement).click();
 
             let attempts = 0;
             const maxAttempts = 20;
@@ -102,8 +100,19 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
 
             const checkExportButton = () => {
               attempts++;
-              exportButton = targetDocument.querySelector('[data-role="operationBar_export"]');
+              const exportButton = targetDocument.querySelector('[data-role="operationBar_export"]');
+
               if (exportButton) {
+                // 检测类名中是否包含以 -disabled 结尾的类名
+                const classList = Array.from(exportButton.classList);
+                const hasDisabledClass = classList.some(cls => cls.endsWith('-disabled'));
+
+                if (hasDisabledClass) {
+                  reject(new Error('您没有当前文档的下载权限，请联系文档所有者申请"可查看/可下载"权限'));
+                  return;
+                }
+
+                // 有权限，继续导出流程
                 const rect = (exportButton as HTMLElement).getBoundingClientRect();
                 const events = ['pointerover', 'pointerenter', 'mouseover', 'mouseenter'];
                 events.forEach(type => {

--- a/components/DingTalkPage.vue
+++ b/components/DingTalkPage.vue
@@ -1,11 +1,10 @@
 <script lang="ts" setup>
 import { ref, onMounted } from 'vue';
-import { NCard, NSpace, NText, useMessage } from 'naive-ui';
+import { NCard, NSpace, NText } from 'naive-ui';
 import AIMix from './include/AIMix.vue';
 import { getAIMixConfig } from '../services/config';
 import type { AIMixActionItem } from '../services/config';
 
-const message = useMessage();
 const isDingTalkDoc = ref(false);
 
 // AI 操作配置数组（动态加载）
@@ -35,15 +34,6 @@ const checkDingTalkDoc = async () => {
 };
 
 /**
- * 显示错误提示
- */
-const showError = (error: unknown) => {
-  const errorMessage = error instanceof Error ? error.message : String(error);
-  message.error(errorMessage);
-  console.error('钉钉文档操作失败:', error);
-};
-
-/**
  * 获取钉钉文档 Markdown 内容
  * 封装：触发导出 → 监听下载 → 读取文件内容
  * 返回对象，key 对应 prompt 模板中的变量名 {content}
@@ -54,9 +44,7 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
       const [activeTab] = await browser.tabs.query({ active: true, currentWindow: true });
 
       if (!activeTab || !activeTab.id) {
-        const error = new Error('无法获取当前标签页');
-        showError(error);
-        reject(error);
+        reject(new Error('无法获取当前标签页'));
         return;
       }
 
@@ -68,9 +56,7 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
       browser.runtime.sendMessage({ action: 'waitForDingMarkdownDownload', origin: pageOrigin }, async (response) => {
         console.log('下载对象:', response);
         if (!response?.success || !response?.downloadItem?.finalUrl) {
-          const error = new Error('未获取到下载文件');
-          showError(error);
-          reject(error);
+          reject(new Error('未获取到下载文件'));
           return;
         }
 
@@ -78,9 +64,7 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
           const res = await fetch(response.downloadItem.finalUrl);
 
           if (!res.ok) {
-            const error = new Error(`下载失败: ${res.status}`);
-            showError(error);
-            reject(error);
+            reject(new Error(`下载失败: ${res.status}`));
             return;
           }
 
@@ -89,7 +73,6 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
           console.log('Markdown 内容:', text);
           resolve({ content: text });
         } catch (error) {
-          showError(error);
           reject(error);
         }
       });
@@ -168,20 +151,15 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
       } catch (execError) {
         // executeScript 本身抛出异常
         const errorMessage = execError instanceof Error ? execError.message : String(execError);
-        const error = new Error(`脚本执行异常: ${errorMessage}`);
-        showError(error);
-        throw error;
+        throw new Error(`脚本执行异常: ${errorMessage}`);
       }
 
       // 检查脚本执行结果
       if (!scriptResult?.result?.success) {
         const errorMessage = scriptResult?.result?.error || '页面脚本执行失败';
-        const error = new Error(errorMessage);
-        showError(error);
-        throw error;
+        throw new Error(errorMessage);
       }
     } catch (error) {
-      showError(error);
       reject(error);
     }
   });

--- a/components/DingTalkPage.vue
+++ b/components/DingTalkPage.vue
@@ -95,78 +95,88 @@ const getDingTalkMarkdown = (): Promise<Record<string, string>> => {
       });
 
       // 在页面中执行导出操作
-      const [scriptResult] = await browser.scripting.executeScript({
-        target: { tabId: activeTab.id },
-        func: () => {
-          return new Promise<void>((resolve, reject) => {
-            const iframe = document.getElementById('wiki-doc-iframe') as HTMLIFrameElement;
-            const targetDocument = (iframe && iframe.contentDocument) ? iframe.contentDocument : document;
+      let scriptResult;
+      try {
+        [scriptResult] = await browser.scripting.executeScript({
+          target: { tabId: activeTab.id },
+          func: () => {
+            return new Promise<{ success: boolean; error?: string }>((resolve) => {
+              const iframe = document.getElementById('wiki-doc-iframe') as HTMLIFrameElement;
+              const targetDocument = (iframe && iframe.contentDocument) ? iframe.contentDocument : document;
 
-            const headerButton = targetDocument.querySelector('button[data-role="headerMoreMenu"]');
-            if (!headerButton) {
-              reject(new Error('未找到 headerMoreMenu 按钮'));
-              return;
-            }
-
-            // 点击菜单按钮展开选项
-            (headerButton as HTMLElement).click();
-
-            let attempts = 0;
-            const maxAttempts = 20;
-            const interval = 500;
-
-            const checkExportButton = () => {
-              attempts++;
-              const exportButton = targetDocument.querySelector('[data-role="operationBar_export"]');
-
-              if (exportButton) {
-                // 检测类名中是否包含以 -disabled 结尾的类名
-                const classList = Array.from(exportButton.classList);
-                const hasDisabledClass = classList.some(cls => cls.endsWith('-disabled'));
-
-                if (hasDisabledClass) {
-                  reject(new Error('您没有当前文档的下载权限，请联系文档所有者申请"可查看/可下载"权限'));
-                  return;
-                }
-
-                // 有权限，继续导出流程
-                const rect = (exportButton as HTMLElement).getBoundingClientRect();
-                const events = ['pointerover', 'pointerenter', 'mouseover', 'mouseenter'];
-                events.forEach(type => {
-                  (exportButton as HTMLElement).dispatchEvent(new PointerEvent(type, {
-                    bubbles: true,
-                    cancelable: true,
-                    composed: true,
-                    clientX: rect.left + rect.width / 2,
-                    clientY: rect.top + rect.height / 2,
-                    view: window,
-                  }));
-                });
-
-                setTimeout(() => {
-                  const exportMdButton = targetDocument.querySelector('[data-role="operationBar__export_exportAsMd"]');
-                  if (exportMdButton) {
-                    (exportMdButton as HTMLElement).click();
-                    resolve();
-                  } else {
-                    reject(new Error('未找到导出为 Markdown 按钮'));
-                  }
-                }, 500);
-              } else if (attempts >= maxAttempts) {
-                reject(new Error('查找导出按钮超时，最多尝试20次'));
-              } else {
-                setTimeout(checkExportButton, interval);
+              const headerButton = targetDocument.querySelector('button[data-role="headerMoreMenu"]');
+              if (!headerButton) {
+                resolve({ success: false, error: '未找到 headerMoreMenu 按钮' });
+                return;
               }
-            };
 
-            checkExportButton();
-          });
-        },
-      });
+              // 点击菜单按钮展开选项
+              (headerButton as HTMLElement).click();
 
-      // 检查脚本执行结果 - 如果页面内 Promise reject，结果会包含异常信息
-      if (scriptResult?.error) {
-        const error = new Error(scriptResult.error.message || '页面脚本执行失败');
+              let attempts = 0;
+              const maxAttempts = 20;
+              const interval = 500;
+
+              const checkExportButton = () => {
+                attempts++;
+                const exportButton = targetDocument.querySelector('[data-role="operationBar_export"]');
+
+                if (exportButton) {
+                  // 检测类名中是否包含以 -disabled 结尾的类名
+                  const classList = Array.from(exportButton.classList);
+                  const hasDisabledClass = classList.some(cls => cls.endsWith('-disabled'));
+
+                  if (hasDisabledClass) {
+                    resolve({ success: false, error: '您没有当前文档的下载权限，请联系文档所有者申请"可查看/可下载"权限' });
+                    return;
+                  }
+
+                  // 有权限，继续导出流程
+                  const rect = (exportButton as HTMLElement).getBoundingClientRect();
+                  const events = ['pointerover', 'pointerenter', 'mouseover', 'mouseenter'];
+                  events.forEach(type => {
+                    (exportButton as HTMLElement).dispatchEvent(new PointerEvent(type, {
+                      bubbles: true,
+                      cancelable: true,
+                      composed: true,
+                      clientX: rect.left + rect.width / 2,
+                      clientY: rect.top + rect.height / 2,
+                      view: window,
+                    }));
+                  });
+
+                  setTimeout(() => {
+                    const exportMdButton = targetDocument.querySelector('[data-role="operationBar__export_exportAsMd"]');
+                    if (exportMdButton) {
+                      (exportMdButton as HTMLElement).click();
+                      resolve({ success: true });
+                    } else {
+                      resolve({ success: false, error: '未找到导出为 Markdown 按钮' });
+                    }
+                  }, 500);
+                } else if (attempts >= maxAttempts) {
+                  resolve({ success: false, error: '查找导出按钮超时，最多尝试20次' });
+                } else {
+                  setTimeout(checkExportButton, interval);
+                }
+              };
+
+              checkExportButton();
+            });
+          },
+        });
+      } catch (execError) {
+        // executeScript 本身抛出异常
+        const errorMessage = execError instanceof Error ? execError.message : String(execError);
+        const error = new Error(`脚本执行异常: ${errorMessage}`);
+        showError(error);
+        throw error;
+      }
+
+      // 检查脚本执行结果
+      if (!scriptResult?.result?.success) {
+        const errorMessage = scriptResult?.result?.error || '页面脚本执行失败';
+        const error = new Error(errorMessage);
         showError(error);
         throw error;
       }


### PR DESCRIPTION
- Add checkDownloadPermission function to detect disabled export button
- Use generic '-disabled' class suffix detection for better compatibility
- Show warning alert when user lacks download permission
- Check permission before attempting export to provide clear error message
- Fix #8