### PR TITLE
fix: GitLab AIMIX 统一注入 wegent_code_bot 并强制替换策略保留其余 tools

### DIFF
--- a/components/GitLabPage.vue
+++ b/components/GitLabPage.vue
@@ -53,8 +53,10 @@ const getMrDetails = async (projectPath: string, mrIid: string) => {
   return await gitlabApi.service.getMergeRequestDetails(projectPath, mrIid);
 };
 
-// 动态获取 AI Review 配置（仅返回动态 tools）
-const getAiReviewDynamicConfig = async () => {
+// 动态获取 code bot 配置（返回携带 workspace 的 wegent_code_bot tool）
+// AIAction.vue 的 mergeTools 会先删除 base 中已有的 wegent_code_bot，再追加此处返回的新条目，
+// 其余 tools（如 skill、mcp 等）原样保留
+const getCodeBotDynamicConfig = async () => {
   // 1. 解析当前 MR URL
   const cleanedUrl = cleanMrUrl(currentUrl.value);
   const parsed = parseMergeRequestUrl(cleanedUrl);
@@ -111,16 +113,13 @@ const loadAIMixConfig = async () => {
   try {
     const config = await getAIMixConfig();
 
-    // 为 GitLab 配置注入动态 getAiConfig 方法
-    aiMixActions.value = config.gitLab.actions.map(action => {
-      if (action.buttonLabel === 'AI协助Review') {
-        return {
-          ...action,
-          getAiConfig: getAiReviewDynamicConfig,
-        };
-      }
-      return action;
-    });
+    // 所有 GitLab actions 统一注入 getCodeBotDynamicConfig：
+    // wegent_code_bot 始终以携带 workspace 的最新版本为准（强制替换已有条目或直接追加），
+    // 其他 tools（skill、mcp 等）由 AIAction.vue 的 mergeTools 原样保留
+    aiMixActions.value = config.gitLab.actions.map(action => ({
+      ...action,
+      getAiConfig: getCodeBotDynamicConfig,
+    }));
   } catch (error) {
     console.error('加载 AI Mix 配置失败:', error);
     aiMixActions.value = [];

--- a/components/include/AIAction.vue
+++ b/components/include/AIAction.vue
@@ -36,15 +36,36 @@ const renderedPrompt = ref('');
 const resolvedAiConfig = ref<AiConfig | null>(null);
 
 /**
+ * 合并 tools 数组：
+ * - 先从 base 中删除与 override 同 type 的条目（强制替换，不保留旧配置）
+ * - 再将 override 条目追加到末尾
+ * - base 中其余 type 原样保留
+ *
+ * 示例：
+ *   base:     [{ type: 'skill', ... }, { type: 'wegent_code_bot' }]
+ *   override: [{ type: 'wegent_code_bot', workspace: {...} }]
+ *   result:   [{ type: 'skill', ... }, { type: 'wegent_code_bot', workspace: {...} }]
+ */
+const mergeTools = (base: ToolConfig[], override: ToolConfig[]): ToolConfig[] => {
+  if (override.length === 0) return base;
+
+  const overrideTypes = new Set(override.map(t => t.type));
+  // 移除 base 中已被 override 覆盖的同类型条目
+  const filtered = base.filter(t => !overrideTypes.has(t.type));
+  // 将 override 条目追加到末尾
+  return [...filtered, ...override];
+};
+
+/**
  * 合并两个 AI 配置
  * - getAiConfig 返回的配置优先级更高
- * - tools 数组进行合并
+ * - tools 数组：override 同类型条目强制替换 base 中的，其余保留
  */
 const mergeAiConfig = (base: AiConfig, override: Partial<AiConfig>): AiConfig => {
   return {
     promptTemplate: override.promptTemplate ?? base.promptTemplate,
     model: override.model ?? base.model,
-    tools: [...(base.tools || []), ...(override.tools || [])],
+    tools: mergeTools(base.tools || [], override.tools || []),
   };
 };
 


### PR DESCRIPTION
## 问题

1. GitLab AIMIX 中只有 `AI协助Review` 才注入 `wegent_code_bot`，其他 actions（含用户自定义含 `skill`、`mcp` 等 tools 的配置）缺少编码模式和 workspace 信息
2. 旧逻辑对 tools 做简单数组拼接，若用户已配置 `wegent_code_bot` 会产生重复条目

## 修改内容

### `components/include/AIAction.vue`

重写 `mergeTools`，采用**强制替换**策略：
- 先从 base 中删除与 override **同 type** 的条目
- 再将 override 条目追加到末尾
- base 中其余 type（`skill`、`mcp` 等）**原样保留**

### `components/GitLabPage.vue`

- `getAiReviewDynamicConfig` 重命名为 `getCodeBotDynamicConfig`，语义更通用
- `loadAIMixConfig` 移除所有条件判断，对**所有** GitLab actions 无条件注入 `getCodeBotDynamicConfig`

## 场景覆盖

| 用户 tools 配置 | 最终 tools 结果 |
|---|---|
| 未配置 | `[wegent_code_bot+workspace]` ✅ |
| 只配了 `skill` | `[skill, wegent_code_bot+workspace]` ✅ |
| 只配了 `wegent_code_bot`（无 workspace）| `[wegent_code_bot+workspace]`（旧条目替换）✅ |
| 配了 `skill` + `wegent_code_bot` | `[skill, wegent_code_bot+workspace]` ✅ |
| 配了 `skill` + `mcp` + `wegent_code_bot` | `[skill, mcp, wegent_code_bot+workspace]` ✅ |

closes #13